### PR TITLE
Add accessory callbacks and raw binder subscriptions

### DIFF
--- a/bridge-shared/aidl/com/penumbraos/bridge/IAccessoryProvider.aidl
+++ b/bridge-shared/aidl/com/penumbraos/bridge/IAccessoryProvider.aidl
@@ -1,7 +1,10 @@
 package com.penumbraos.bridge;
 
 import com.penumbraos.bridge.types.AccessoryBatteryInfo;
+import com.penumbraos.bridge.callback.IAccessoryCallback;
 
 interface IAccessoryProvider {
     AccessoryBatteryInfo getBatteryInfo();
+    void registerCallback(IAccessoryCallback callback);
+    void deregisterCallback(IAccessoryCallback callback);
 }

--- a/bridge-shared/aidl/com/penumbraos/bridge/callback/IAccessoryCallback.aidl
+++ b/bridge-shared/aidl/com/penumbraos/bridge/callback/IAccessoryCallback.aidl
@@ -1,0 +1,7 @@
+package com.penumbraos.bridge.callback;
+
+import com.penumbraos.bridge.types.AccessoryBatteryInfo;
+
+oneway interface IAccessoryCallback {
+    void onBatteryInfoChanged(in AccessoryBatteryInfo info);
+}

--- a/bridge-shared/aidl/com/penumbraos/bridge/types/AccessoryBatteryInfo.aidl
+++ b/bridge-shared/aidl/com/penumbraos/bridge/types/AccessoryBatteryInfo.aidl
@@ -4,4 +4,8 @@ parcelable AccessoryBatteryInfo {
     int boosterBatteryLevel;
     boolean boosterBatteryCharging;
     boolean boosterBatteryConnected;
+    /** Stock DMAccessoryState: 1=disconnected, 2=connected, 128=maybe_connected */
+    int boosterConnectionState;
+    boolean isOnChargePad;
+    boolean isInChargeCase;
 }

--- a/bridge-shared/aidl/com/penumbraos/bridge/types/AccessoryBatteryInfo.aidl
+++ b/bridge-shared/aidl/com/penumbraos/bridge/types/AccessoryBatteryInfo.aidl
@@ -4,7 +4,6 @@ parcelable AccessoryBatteryInfo {
     int boosterBatteryLevel;
     boolean boosterBatteryCharging;
     boolean boosterBatteryConnected;
-    /** Stock DMAccessoryState: 1=disconnected, 2=connected, 128=maybe_connected */
     int boosterConnectionState;
     boolean isOnChargePad;
     boolean isInChargeCase;

--- a/bridge-shell/src/main/java/com/penumbraos/bridge_shell/provider/AccessoryEventBinder.kt
+++ b/bridge-shell/src/main/java/com/penumbraos/bridge_shell/provider/AccessoryEventBinder.kt
@@ -1,0 +1,60 @@
+package com.penumbraos.bridge_shell.provider
+
+import android.os.Binder
+import android.os.Parcel
+import android.util.Log
+
+private const val TAG = "AccessoryEventBinder"
+private const val DESCRIPTOR = "humane.devicemanager.IDMAccessoryEventsCallback"
+private const val TRANSACTION_onAccessoryEvent = 1
+private const val TRANSACTION_onBatteryLevelChangeEvent = 2
+private const val INTERFACE_TRANSACTION = 1598968902 // IBinder.INTERFACE_TRANSACTION
+
+/**
+ * Raw Binder implementation of humane.devicemanager.IDMAccessoryEventsCallback.
+ *
+ * This bypasses reflection-based proxy issues by implementing the exact same
+ * binder wire protocol as the stock IDMAccessoryEventsCallback.Stub. The
+ * humane.devicemanager service doesn't check the Java class — it only
+ * transacts on the binder using the DESCRIPTOR and transaction codes.
+ *
+ * From decompiled IDMAccessoryEventsCallback.Stub.onTransact():
+ *   - Transaction 1 (onAccessoryEvent): reads two ints (from, to)
+ *   - Transaction 2 (onBatteryLevelChangeEvent): reads two ints (fromLevel, toLevel)
+ *   - Both enforce interface token "humane.devicemanager.IDMAccessoryEventsCallback"
+ */
+class AccessoryEventBinder(
+    private val onAccessoryEvent: (from: Int, to: Int) -> Unit,
+    private val onBatteryLevelChangeEvent: (fromLevel: Int, toLevel: Int) -> Unit,
+) : Binder() {
+
+    init {
+        attachInterface(null, DESCRIPTOR)
+    }
+
+    override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
+        return when (code) {
+            INTERFACE_TRANSACTION -> {
+                reply?.writeString(DESCRIPTOR)
+                true
+            }
+            TRANSACTION_onAccessoryEvent -> {
+                data.enforceInterface(DESCRIPTOR)
+                val from = data.readInt()
+                val to = data.readInt()
+                Log.d(TAG, "onAccessoryEvent: from=$from to=$to")
+                onAccessoryEvent(from, to)
+                true
+            }
+            TRANSACTION_onBatteryLevelChangeEvent -> {
+                data.enforceInterface(DESCRIPTOR)
+                val fromLevel = data.readInt()
+                val toLevel = data.readInt()
+                Log.d(TAG, "onBatteryLevelChangeEvent: from=$fromLevel to=$toLevel")
+                onBatteryLevelChangeEvent(fromLevel, toLevel)
+                true
+            }
+            else -> super.onTransact(code, data, reply, flags)
+        }
+    }
+}

--- a/bridge-shell/src/main/java/com/penumbraos/bridge_shell/provider/AccessoryEventBinder.kt
+++ b/bridge-shell/src/main/java/com/penumbraos/bridge_shell/provider/AccessoryEventBinder.kt
@@ -6,23 +6,10 @@ import android.util.Log
 
 private const val TAG = "AccessoryEventBinder"
 private const val DESCRIPTOR = "humane.devicemanager.IDMAccessoryEventsCallback"
-private const val TRANSACTION_onAccessoryEvent = 1
-private const val TRANSACTION_onBatteryLevelChangeEvent = 2
+private const val TRANSACTION_ON_ACCESSORY_EVENT = 1
+private const val TRANSACTION_ON_BATTERY_LEVEL_CHANGE_EVENT = 2
 private const val INTERFACE_TRANSACTION = 1598968902 // IBinder.INTERFACE_TRANSACTION
 
-/**
- * Raw Binder implementation of humane.devicemanager.IDMAccessoryEventsCallback.
- *
- * This bypasses reflection-based proxy issues by implementing the exact same
- * binder wire protocol as the stock IDMAccessoryEventsCallback.Stub. The
- * humane.devicemanager service doesn't check the Java class — it only
- * transacts on the binder using the DESCRIPTOR and transaction codes.
- *
- * From decompiled IDMAccessoryEventsCallback.Stub.onTransact():
- *   - Transaction 1 (onAccessoryEvent): reads two ints (from, to)
- *   - Transaction 2 (onBatteryLevelChangeEvent): reads two ints (fromLevel, toLevel)
- *   - Both enforce interface token "humane.devicemanager.IDMAccessoryEventsCallback"
- */
 class AccessoryEventBinder(
     private val onAccessoryEvent: (from: Int, to: Int) -> Unit,
     private val onBatteryLevelChangeEvent: (fromLevel: Int, toLevel: Int) -> Unit,
@@ -38,7 +25,7 @@ class AccessoryEventBinder(
                 reply?.writeString(DESCRIPTOR)
                 true
             }
-            TRANSACTION_onAccessoryEvent -> {
+            TRANSACTION_ON_ACCESSORY_EVENT -> {
                 data.enforceInterface(DESCRIPTOR)
                 val from = data.readInt()
                 val to = data.readInt()
@@ -46,7 +33,7 @@ class AccessoryEventBinder(
                 onAccessoryEvent(from, to)
                 true
             }
-            TRANSACTION_onBatteryLevelChangeEvent -> {
+            TRANSACTION_ON_BATTERY_LEVEL_CHANGE_EVENT -> {
                 data.enforceInterface(DESCRIPTOR)
                 val fromLevel = data.readInt()
                 val toLevel = data.readInt()

--- a/bridge-shell/src/main/java/com/penumbraos/bridge_shell/provider/AccessoryProvider.kt
+++ b/bridge-shell/src/main/java/com/penumbraos/bridge_shell/provider/AccessoryProvider.kt
@@ -1,9 +1,7 @@
 package com.penumbraos.bridge_shell.provider
 
 import android.content.Context
-import android.os.Binder
 import android.os.IBinder
-import android.os.Parcel
 import android.os.ServiceManager
 import android.util.Log
 import com.penumbraos.bridge.IAccessoryProvider
@@ -18,17 +16,17 @@ private const val TAG = "AccessoryProvider"
 /**
  * Provides battery and accessory state from humane.devicemanager.
  *
- * Uses raw binder transactions (not reflection) to subscribe to accessory
- * state changes. The humane.devicemanager service's subscribeToAccessoryState()
- * method expects an IDMAccessoryEventsCallback binder. We can't pass a
- * Proxy.newProxyInstance or reflected object because Method.invoke() enforces
- * parameter types. Instead, we transact directly on the raw IBinder using
- * the same Parcel protocol as IDeviceManager.Stub.Proxy.
+ * Uses reflection to call IDeviceManager methods (isConnected, getBatteryState).
+ *
+ * SELinux on the AI Pin blocks binder `transfer` from shell context to
+ * device_manager, so we cannot use push-based subscriptions
+ * (subscribeToAccessoryState). Instead, we poll the device manager at a
+ * regular interval and notify SDK callbacks when state changes.
  *
  * Stock subscription pattern (from decompiled PowerLevelManager.java):
- *   - Booster (type 0, mask 135): connection state + battery level changes
- *   - Charge pad (type 2, mask 3): connection state only
- *   - Charge case (type 1, mask 3): connection state only
+ *   - Booster (type 0): connection state + battery level
+ *   - Charge pad (type 2): connection state only
+ *   - Charge case (type 1): connection state only
  */
 class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
 
@@ -41,13 +39,13 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
     private var isConnectedMethod: Method
     private var batteryStateClass: Class<*>
 
-    // ─── Cached live state (updated by subscriptions) ───
+    // ─── Cached live state (updated by polling) ───
 
     /** Booster battery level percent (0-100, or -1 if disconnected) */
-    private var boosterLevel: Int = -1
+    @Volatile private var boosterLevel: Int = -1
 
     /** Whether booster is currently charging */
-    private var boosterCharging: Boolean = false
+    @Volatile private var boosterCharging: Boolean = false
 
     /**
      * Booster connection state (stock DMAccessoryState values):
@@ -55,20 +53,22 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
      *   2 = CONNECTED
      *   128 = MAYBE_CONNECTED
      */
-    private var boosterConnectionState: Int = STATE_DISCONNECTED
+    @Volatile private var boosterConnectionState: Int = STATE_DISCONNECTED
 
     /** Whether the pin is sitting on the charge pad */
-    private var isOnChargePad: Boolean = false
+    @Volatile private var isOnChargePad: Boolean = false
 
     /** Whether the pin is in the charge case */
-    private var isInChargeCase: Boolean = false
-
-    /** Whether we've subscribed to DeviceManager events */
-    private var subscribed = false
+    @Volatile private var isInChargeCase: Boolean = false
 
     // ─── SDK callbacks ───
 
     private val sdkCallbacks = mutableListOf<IAccessoryCallback>()
+
+    // ─── Polling ───
+
+    private var pollingThread: Thread? = null
+    @Volatile private var pollingActive = false
 
     companion object {
         // Stock DMAccessoryState constants
@@ -76,13 +76,8 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
         const val STATE_CONNECTED = 2
         const val STATE_MAYBE_CONNECTED = 128
 
-        // Stock state mask constants (from PowerLevelManager)
-        const val BOOSTER_STATE_MASK = 135   // stock uses for type 0
-        const val CASE_PAD_STATE_MASK = 3    // stock uses for types 1 and 2
-
-        // IDeviceManager transaction codes (from decompiled Stub)
-        const val TRANSACTION_subscribeToAccessoryState = 2
-        const val IDEVICEMANAGER_DESCRIPTOR = "humane.devicemanager.IDeviceManager"
+        /** Polling interval in milliseconds */
+        const val POLL_INTERVAL_MS = 5_000L
     }
 
     init {
@@ -105,53 +100,15 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
     // ─── IAccessoryProvider implementation ───
 
     override fun getBatteryInfo(): AccessoryBatteryInfo? {
-        if (deviceManagerService == null || deviceManagerBinder?.isBinderAlive != true) {
-            Log.w(TAG, "Device Manager service not connected")
-            connectToDeviceManager()
-        }
+        ensureConnected()
+        if (deviceManagerService == null) return null
 
-        if (deviceManagerService == null || deviceManagerBinder?.isBinderAlive != true) {
-            Log.w(TAG, "Device Manager service not connected. Giving up")
-            return null
-        }
-
-        // If subscribed, return cached state (more accurate — push-updated)
-        if (subscribed) {
-            return buildBatteryInfo()
-        }
-
-        // Fallback: poll (original behavior)
         return try {
-            val connectionStatus = isConnectedMethod.invoke(deviceManagerService, 0) as Int
-            val isConnected = connectionStatus != STATE_DISCONNECTED
-
-            val batteryStateObject = batteryStateClass.getConstructor().newInstance()
-            val result =
-                getBatteryStateMethod.invoke(deviceManagerService, 0, batteryStateObject) as Int
-
-            if (result == 0) {
-                val levelPercentField = batteryStateClass.getField("levelPercent")
-                val b1Level = levelPercentField.getInt(batteryStateObject)
-
-                val isChargingField = batteryStateClass.getField("isCharging")
-                val isCharging = isChargingField.getBoolean(batteryStateObject)
-
-                AccessoryBatteryInfo().apply {
-                    boosterBatteryLevel = if (isConnected) b1Level else -1
-                    boosterBatteryCharging = isConnected && isCharging
-                    boosterBatteryConnected = isConnected
-                    boosterConnectionState = connectionStatus
-                    this.isOnChargePad = this@AccessoryProvider.isOnChargePad
-                    this.isInChargeCase = this@AccessoryProvider.isInChargeCase
-                }
-            } else {
-                Log.e(TAG, "Failed to get B1 battery state, result: $result")
-                null
-            }
+            pollAllAccessoryState()
+            buildBatteryInfo()
         } catch (e: Exception) {
-            Log.e(TAG, "Error refreshing B1 battery state", e)
-            deviceManagerService = null
-            deviceManagerBinder = null
+            Log.e(TAG, "Error getting battery info", e)
+            handleConnectionError()
             null
         }
     }
@@ -166,175 +123,135 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
         sdkCallbacks.add(callback)
         Log.i(TAG, "Registered callback (total: ${sdkCallbacks.size})")
 
-        // Start subscriptions on first callback registration
-        subscribeToDeviceManager()
+        // Start polling on first callback registration
+        startPolling()
 
         // Send initial state immediately
         try {
+            ensureConnected()
+            if (deviceManagerService != null) {
+                pollAllAccessoryState()
+            }
             callback.onBatteryInfoChanged(buildBatteryInfo())
         } catch (e: Exception) {
             Log.w(TAG, "Failed to send initial battery info", e)
+            handleConnectionError()
+            // Still send what we have (defaults)
+            try { callback.onBatteryInfoChanged(buildBatteryInfo()) } catch (_: Exception) {}
         }
     }
 
     override fun deregisterCallback(callback: IAccessoryCallback) {
         sdkCallbacks.remove(callback)
         Log.i(TAG, "Deregistered callback (remaining: ${sdkCallbacks.size})")
-    }
 
-    // ─── Raw binder subscription ───
-
-    /**
-     * Subscribe to accessory state changes using raw binder transactions.
-     *
-     * This bypasses the reflected subscribeToAccessoryState() method, which fails
-     * because Method.invoke() enforces that the callback parameter's class matches
-     * IDMAccessoryEventsCallback from Humane's classloader. Our AccessoryEventBinder
-     * is a raw Binder that speaks the same wire protocol.
-     *
-     * From decompiled IDeviceManager.Stub.Proxy.subscribeToAccessoryState():
-     *   _data.writeInterfaceToken("humane.devicemanager.IDeviceManager");
-     *   _data.writeInt(type);
-     *   _data.writeInt(states);
-     *   _data.writeStrongInterface(cb);  // → writeStrongBinder(cb.asBinder())
-     *   mRemote.transact(2, _data, _reply, 0);
-     */
-    private fun subscribeRaw(
-        accessoryType: Int,
-        stateMask: Int,
-        callbackBinder: Binder
-    ): Int {
-        val binder = deviceManagerBinder ?: return -1
-        val data = Parcel.obtain()
-        val reply = Parcel.obtain()
-        try {
-            data.writeInterfaceToken(IDEVICEMANAGER_DESCRIPTOR)
-            data.writeInt(accessoryType)
-            data.writeInt(stateMask)
-            data.writeStrongBinder(callbackBinder)
-            binder.transact(TRANSACTION_subscribeToAccessoryState, data, reply, 0)
-            reply.readException()
-            return reply.readInt()
-        } finally {
-            data.recycle()
-            reply.recycle()
+        // Stop polling when no callbacks remain
+        if (sdkCallbacks.isEmpty()) {
+            stopPolling()
         }
     }
 
+    // ─── Polling loop ───
+
     /**
-     * Subscribe to all accessory events (booster, charge pad, charge case).
-     * Matches stock PowerLevelManager initialization pattern exactly.
+     * Start a background polling thread that queries the device manager
+     * every [POLL_INTERVAL_MS] and notifies callbacks on state changes.
      */
-    private fun subscribeToDeviceManager() {
-        if (subscribed) return
+    private fun startPolling() {
+        if (pollingActive) return
+        pollingActive = true
 
-        connectToDeviceManager()
-        if (deviceManagerBinder == null) {
-            Log.w(TAG, "Cannot subscribe — Device Manager not available")
-            return
-        }
+        pollingThread = Thread({
+            Log.i(TAG, "Polling thread started (interval=${POLL_INTERVAL_MS}ms)")
+            while (pollingActive) {
+                try {
+                    Thread.sleep(POLL_INTERVAL_MS)
+                } catch (_: InterruptedException) {
+                    break
+                }
+                if (!pollingActive) break
 
-        try {
-            // Get initial booster state (stock: PowerLevelManager.getInitialBoosterState)
-            val connectionStatus = isConnectedMethod.invoke(deviceManagerService, 0) as Int
-            boosterConnectionState = connectionStatus
-
-            if (connectionStatus == STATE_CONNECTED) {
-                refreshBoosterBattery()
-            } else if (connectionStatus == STATE_MAYBE_CONNECTED) {
-                boosterLevel = 0
-            } else {
-                boosterLevel = 0
-            }
-
-            // Get initial charge case state (stock: PowerLevelManager.getInitialChargeCaseState)
-            val chargeCaseStatus = isConnectedMethod.invoke(deviceManagerService, 1) as Int
-            isInChargeCase = (chargeCaseStatus == STATE_CONNECTED)
-
-            // Subscribe to booster (type 0, mask 135) — connection + battery changes
-            val boosterCallback = AccessoryEventBinder(
-                onAccessoryEvent = { from, to ->
-                    when (to) {
-                        STATE_CONNECTED -> {
-                            boosterConnectionState = STATE_CONNECTED
-                            // Stock: on connect, immediately fetch fresh battery level
-                            refreshBoosterBattery()
-                        }
-                        STATE_DISCONNECTED -> {
-                            boosterConnectionState = STATE_DISCONNECTED
-                            boosterLevel = 0
-                            boosterCharging = false
-                        }
-                        STATE_MAYBE_CONNECTED -> {
-                            boosterConnectionState = STATE_MAYBE_CONNECTED
-                            boosterLevel = 0
-                            boosterCharging = false
+                try {
+                    ensureConnected()
+                    if (deviceManagerService != null) {
+                        val changed = pollAllAccessoryState()
+                        if (changed) {
+                            notifyCallbacks()
                         }
                     }
-                    notifyCallbacks()
-                },
-                onBatteryLevelChangeEvent = { _, toLevel ->
-                    boosterLevel = toLevel
-                    notifyCallbacks()
+                } catch (e: Exception) {
+                    Log.w(TAG, "Poll cycle failed: ${e.message}")
+                    handleConnectionError()
                 }
-            )
-            val boosterResult = subscribeRaw(0, BOOSTER_STATE_MASK, boosterCallback)
-            Log.i(TAG, "Subscribed to booster (type 0), result=$boosterResult")
-
-            // Subscribe to charge pad (type 2, mask 3) — connection only
-            val chargePadCallback = AccessoryEventBinder(
-                onAccessoryEvent = { from, to ->
-                    isOnChargePad = (to == STATE_CONNECTED)
-                    Log.d(TAG, "Charge pad: ${if (isOnChargePad) "connected" else "disconnected"}")
-                    notifyCallbacks()
-                },
-                onBatteryLevelChangeEvent = { _, _ -> }
-            )
-            val padResult = subscribeRaw(2, CASE_PAD_STATE_MASK, chargePadCallback)
-            Log.i(TAG, "Subscribed to charge pad (type 2), result=$padResult")
-
-            // Subscribe to charge case (type 1, mask 3) — connection only
-            val chargeCaseCallback = AccessoryEventBinder(
-                onAccessoryEvent = { from, to ->
-                    isInChargeCase = (to == STATE_CONNECTED)
-                    Log.d(TAG, "Charge case: ${if (isInChargeCase) "connected" else "disconnected"}")
-                    notifyCallbacks()
-                },
-                onBatteryLevelChangeEvent = { _, _ -> }
-            )
-            val caseResult = subscribeRaw(1, CASE_PAD_STATE_MASK, chargeCaseCallback)
-            Log.i(TAG, "Subscribed to charge case (type 1), result=$caseResult")
-
-            subscribed = true
-            Log.i(TAG, "Subscribed to all accessory state events")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to subscribe to accessory events", e)
+            }
+            Log.i(TAG, "Polling thread stopped")
+        }, "AccessoryProvider-poll").also {
+            it.isDaemon = true
+            it.start()
         }
     }
 
+    private fun stopPolling() {
+        pollingActive = false
+        pollingThread?.interrupt()
+        pollingThread = null
+        Log.i(TAG, "Polling stopped")
+    }
+
     /**
-     * Fetch current booster battery level and charging status via reflection.
-     * Stock: PowerLevelManager calls getBatteryState(0, state) after connect.
+     * Poll all accessory types and update cached state.
+     * Returns true if any state changed since last poll.
      */
-    private fun refreshBoosterBattery() {
+    private fun pollAllAccessoryState(): Boolean {
+        val svc = deviceManagerService ?: return false
+        var changed = false
+
         try {
-            val batteryStateObject = batteryStateClass.getConstructor().newInstance()
-            val result =
-                getBatteryStateMethod.invoke(deviceManagerService, 0, batteryStateObject) as Int
-            if (result == 0) {
-                val levelPercentField = batteryStateClass.getField("levelPercent")
-                boosterLevel = levelPercentField.getInt(batteryStateObject)
+            // Poll booster (type 0)
+            val oldBoosterConn = boosterConnectionState
+            val oldBoosterLevel = boosterLevel
+            val oldBoosterCharging = boosterCharging
 
-                val isChargingField = batteryStateClass.getField("isCharging")
-                boosterCharging = isChargingField.getBoolean(batteryStateObject)
+            val boosterConnStatus = isConnectedMethod.invoke(svc, 0) as Int
+            boosterConnectionState = boosterConnStatus
 
-                Log.d(TAG, "Booster battery: ${boosterLevel}%, charging=$boosterCharging")
+            if (boosterConnStatus == STATE_CONNECTED) {
+                val batteryStateObject = batteryStateClass.getConstructor().newInstance()
+                val result = getBatteryStateMethod.invoke(svc, 0, batteryStateObject) as Int
+                if (result == 0) {
+                    boosterLevel = batteryStateClass.getField("levelPercent").getInt(batteryStateObject)
+                    boosterCharging = batteryStateClass.getField("isCharging").getBoolean(batteryStateObject)
+                }
             } else {
-                Log.w(TAG, "getBatteryState failed, result=$result")
+                boosterLevel = 0
+                boosterCharging = false
             }
+
+            if (oldBoosterConn != boosterConnectionState ||
+                oldBoosterLevel != boosterLevel ||
+                oldBoosterCharging != boosterCharging) {
+                changed = true
+            }
+
+            // Poll charge pad (type 2)
+            val oldPad = isOnChargePad
+            val padStatus = isConnectedMethod.invoke(svc, 2) as Int
+            isOnChargePad = (padStatus == STATE_CONNECTED)
+            if (oldPad != isOnChargePad) changed = true
+
+            // Poll charge case (type 1)
+            val oldCase = isInChargeCase
+            val caseStatus = isConnectedMethod.invoke(svc, 1) as Int
+            isInChargeCase = (caseStatus == STATE_CONNECTED)
+            if (oldCase != isInChargeCase) changed = true
+
         } catch (e: Exception) {
-            Log.e(TAG, "Error refreshing booster battery", e)
+            Log.w(TAG, "pollAllAccessoryState failed: ${e.message}")
+            handleConnectionError()
+            throw e
         }
+
+        return changed
     }
 
     // ─── Callback notification ───
@@ -364,9 +281,25 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
         }
 
         dead.forEach { deregisterCallback(it) }
+
+        if (dead.isEmpty()) {
+            Log.d(TAG, "Notified ${sdkCallbacks.size} callbacks: " +
+                "booster=${boosterLevel}% conn=${boosterConnectionState} " +
+                "charging=$boosterCharging pad=$isOnChargePad case=$isInChargeCase")
+        }
     }
 
-    // ─── Connection ───
+    // ─── Connection management ───
+
+    private fun ensureConnected() {
+        if (deviceManagerService != null && deviceManagerBinder?.isBinderAlive == true) return
+        connectToDeviceManager()
+    }
+
+    private fun handleConnectionError() {
+        deviceManagerService = null
+        deviceManagerBinder = null
+    }
 
     private fun connectToDeviceManager() {
         try {

--- a/bridge-shell/src/main/java/com/penumbraos/bridge_shell/provider/AccessoryProvider.kt
+++ b/bridge-shell/src/main/java/com/penumbraos/bridge_shell/provider/AccessoryProvider.kt
@@ -1,16 +1,35 @@
 package com.penumbraos.bridge_shell.provider
 
 import android.content.Context
+import android.os.Binder
 import android.os.IBinder
+import android.os.Parcel
 import android.os.ServiceManager
 import android.util.Log
 import com.penumbraos.bridge.IAccessoryProvider
+import com.penumbraos.bridge.callback.IAccessoryCallback
 import com.penumbraos.bridge.external.getApkClassLoader
+import com.penumbraos.bridge.external.safeCallback
 import com.penumbraos.bridge.types.AccessoryBatteryInfo
 import java.lang.reflect.Method
 
 private const val TAG = "AccessoryProvider"
 
+/**
+ * Provides battery and accessory state from humane.devicemanager.
+ *
+ * Uses raw binder transactions (not reflection) to subscribe to accessory
+ * state changes. The humane.devicemanager service's subscribeToAccessoryState()
+ * method expects an IDMAccessoryEventsCallback binder. We can't pass a
+ * Proxy.newProxyInstance or reflected object because Method.invoke() enforces
+ * parameter types. Instead, we transact directly on the raw IBinder using
+ * the same Parcel protocol as IDeviceManager.Stub.Proxy.
+ *
+ * Stock subscription pattern (from decompiled PowerLevelManager.java):
+ *   - Booster (type 0, mask 135): connection state + battery level changes
+ *   - Charge pad (type 2, mask 3): connection state only
+ *   - Charge case (type 1, mask 3): connection state only
+ */
 class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
 
     private var deviceManagerService: Any? = null
@@ -21,6 +40,50 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
     private var getBatteryStateMethod: Method
     private var isConnectedMethod: Method
     private var batteryStateClass: Class<*>
+
+    // ─── Cached live state (updated by subscriptions) ───
+
+    /** Booster battery level percent (0-100, or -1 if disconnected) */
+    private var boosterLevel: Int = -1
+
+    /** Whether booster is currently charging */
+    private var boosterCharging: Boolean = false
+
+    /**
+     * Booster connection state (stock DMAccessoryState values):
+     *   1 = DISCONNECTED
+     *   2 = CONNECTED
+     *   128 = MAYBE_CONNECTED
+     */
+    private var boosterConnectionState: Int = STATE_DISCONNECTED
+
+    /** Whether the pin is sitting on the charge pad */
+    private var isOnChargePad: Boolean = false
+
+    /** Whether the pin is in the charge case */
+    private var isInChargeCase: Boolean = false
+
+    /** Whether we've subscribed to DeviceManager events */
+    private var subscribed = false
+
+    // ─── SDK callbacks ───
+
+    private val sdkCallbacks = mutableListOf<IAccessoryCallback>()
+
+    companion object {
+        // Stock DMAccessoryState constants
+        const val STATE_DISCONNECTED = 1
+        const val STATE_CONNECTED = 2
+        const val STATE_MAYBE_CONNECTED = 128
+
+        // Stock state mask constants (from PowerLevelManager)
+        const val BOOSTER_STATE_MASK = 135   // stock uses for type 0
+        const val CASE_PAD_STATE_MASK = 3    // stock uses for types 1 and 2
+
+        // IDeviceManager transaction codes (from decompiled Stub)
+        const val TRANSACTION_subscribeToAccessoryState = 2
+        const val IDEVICEMANAGER_DESCRIPTOR = "humane.devicemanager.IDeviceManager"
+    }
 
     init {
         val classLoader = getApkClassLoader(context, "humane.experience.settings")
@@ -39,6 +102,8 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
         isConnectedMethod = iDeviceManagerClass.getMethod("isConnected", Int::class.java)
     }
 
+    // ─── IAccessoryProvider implementation ───
+
     override fun getBatteryInfo(): AccessoryBatteryInfo? {
         if (deviceManagerService == null || deviceManagerBinder?.isBinderAlive != true) {
             Log.w(TAG, "Device Manager service not connected")
@@ -50,20 +115,19 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
             return null
         }
 
+        // If subscribed, return cached state (more accurate — push-updated)
+        if (subscribed) {
+            return buildBatteryInfo()
+        }
+
+        // Fallback: poll (original behavior)
         return try {
-            Log.d(TAG, "PING ${deviceManagerBinder?.pingBinder()}")
+            val connectionStatus = isConnectedMethod.invoke(deviceManagerService, 0) as Int
+            val isConnected = connectionStatus != STATE_DISCONNECTED
 
-            val isConnectedMethod = iDeviceManagerClass.getMethod("isConnected", Int::class.java)
-            val connectionStatus = isConnectedMethod.invoke(deviceManagerService, 0)
-            // If 128, it's "maybeConnected", otherwise connected
-            val isConnected = connectionStatus != 1
-
-            Log.d(TAG, "Device Manager isConnected returned: $isConnected $connectionStatus")
             val batteryStateObject = batteryStateClass.getConstructor().newInstance()
-
             val result =
                 getBatteryStateMethod.invoke(deviceManagerService, 0, batteryStateObject) as Int
-            Log.d(TAG, "getBatteryState returned: $result")
 
             if (result == 0) {
                 val levelPercentField = batteryStateClass.getField("levelPercent")
@@ -72,26 +136,237 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
                 val isChargingField = batteryStateClass.getField("isCharging")
                 val isCharging = isChargingField.getBoolean(batteryStateObject)
 
-                Log.d(TAG, "B1 level: $b1Level")
-
                 AccessoryBatteryInfo().apply {
                     boosterBatteryLevel = if (isConnected) b1Level else -1
                     boosterBatteryCharging = isConnected && isCharging
                     boosterBatteryConnected = isConnected
+                    boosterConnectionState = connectionStatus
+                    this.isOnChargePad = this@AccessoryProvider.isOnChargePad
+                    this.isInChargeCase = this@AccessoryProvider.isInChargeCase
                 }
             } else {
                 Log.e(TAG, "Failed to get B1 battery state, result: $result")
-
                 null
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error refreshing B1 battery state", e)
             deviceManagerService = null
             deviceManagerBinder = null
-
             null
         }
     }
+
+    override fun registerCallback(callback: IAccessoryCallback) {
+        callback.asBinder().linkToDeath(object : IBinder.DeathRecipient {
+            override fun binderDied() {
+                deregisterCallback(callback)
+            }
+        }, 0)
+
+        sdkCallbacks.add(callback)
+        Log.i(TAG, "Registered callback (total: ${sdkCallbacks.size})")
+
+        // Start subscriptions on first callback registration
+        subscribeToDeviceManager()
+
+        // Send initial state immediately
+        try {
+            callback.onBatteryInfoChanged(buildBatteryInfo())
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to send initial battery info", e)
+        }
+    }
+
+    override fun deregisterCallback(callback: IAccessoryCallback) {
+        sdkCallbacks.remove(callback)
+        Log.i(TAG, "Deregistered callback (remaining: ${sdkCallbacks.size})")
+    }
+
+    // ─── Raw binder subscription ───
+
+    /**
+     * Subscribe to accessory state changes using raw binder transactions.
+     *
+     * This bypasses the reflected subscribeToAccessoryState() method, which fails
+     * because Method.invoke() enforces that the callback parameter's class matches
+     * IDMAccessoryEventsCallback from Humane's classloader. Our AccessoryEventBinder
+     * is a raw Binder that speaks the same wire protocol.
+     *
+     * From decompiled IDeviceManager.Stub.Proxy.subscribeToAccessoryState():
+     *   _data.writeInterfaceToken("humane.devicemanager.IDeviceManager");
+     *   _data.writeInt(type);
+     *   _data.writeInt(states);
+     *   _data.writeStrongInterface(cb);  // → writeStrongBinder(cb.asBinder())
+     *   mRemote.transact(2, _data, _reply, 0);
+     */
+    private fun subscribeRaw(
+        accessoryType: Int,
+        stateMask: Int,
+        callbackBinder: Binder
+    ): Int {
+        val binder = deviceManagerBinder ?: return -1
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+        try {
+            data.writeInterfaceToken(IDEVICEMANAGER_DESCRIPTOR)
+            data.writeInt(accessoryType)
+            data.writeInt(stateMask)
+            data.writeStrongBinder(callbackBinder)
+            binder.transact(TRANSACTION_subscribeToAccessoryState, data, reply, 0)
+            reply.readException()
+            return reply.readInt()
+        } finally {
+            data.recycle()
+            reply.recycle()
+        }
+    }
+
+    /**
+     * Subscribe to all accessory events (booster, charge pad, charge case).
+     * Matches stock PowerLevelManager initialization pattern exactly.
+     */
+    private fun subscribeToDeviceManager() {
+        if (subscribed) return
+
+        connectToDeviceManager()
+        if (deviceManagerBinder == null) {
+            Log.w(TAG, "Cannot subscribe — Device Manager not available")
+            return
+        }
+
+        try {
+            // Get initial booster state (stock: PowerLevelManager.getInitialBoosterState)
+            val connectionStatus = isConnectedMethod.invoke(deviceManagerService, 0) as Int
+            boosterConnectionState = connectionStatus
+
+            if (connectionStatus == STATE_CONNECTED) {
+                refreshBoosterBattery()
+            } else if (connectionStatus == STATE_MAYBE_CONNECTED) {
+                boosterLevel = 0
+            } else {
+                boosterLevel = 0
+            }
+
+            // Get initial charge case state (stock: PowerLevelManager.getInitialChargeCaseState)
+            val chargeCaseStatus = isConnectedMethod.invoke(deviceManagerService, 1) as Int
+            isInChargeCase = (chargeCaseStatus == STATE_CONNECTED)
+
+            // Subscribe to booster (type 0, mask 135) — connection + battery changes
+            val boosterCallback = AccessoryEventBinder(
+                onAccessoryEvent = { from, to ->
+                    when (to) {
+                        STATE_CONNECTED -> {
+                            boosterConnectionState = STATE_CONNECTED
+                            // Stock: on connect, immediately fetch fresh battery level
+                            refreshBoosterBattery()
+                        }
+                        STATE_DISCONNECTED -> {
+                            boosterConnectionState = STATE_DISCONNECTED
+                            boosterLevel = 0
+                            boosterCharging = false
+                        }
+                        STATE_MAYBE_CONNECTED -> {
+                            boosterConnectionState = STATE_MAYBE_CONNECTED
+                            boosterLevel = 0
+                            boosterCharging = false
+                        }
+                    }
+                    notifyCallbacks()
+                },
+                onBatteryLevelChangeEvent = { _, toLevel ->
+                    boosterLevel = toLevel
+                    notifyCallbacks()
+                }
+            )
+            val boosterResult = subscribeRaw(0, BOOSTER_STATE_MASK, boosterCallback)
+            Log.i(TAG, "Subscribed to booster (type 0), result=$boosterResult")
+
+            // Subscribe to charge pad (type 2, mask 3) — connection only
+            val chargePadCallback = AccessoryEventBinder(
+                onAccessoryEvent = { from, to ->
+                    isOnChargePad = (to == STATE_CONNECTED)
+                    Log.d(TAG, "Charge pad: ${if (isOnChargePad) "connected" else "disconnected"}")
+                    notifyCallbacks()
+                },
+                onBatteryLevelChangeEvent = { _, _ -> }
+            )
+            val padResult = subscribeRaw(2, CASE_PAD_STATE_MASK, chargePadCallback)
+            Log.i(TAG, "Subscribed to charge pad (type 2), result=$padResult")
+
+            // Subscribe to charge case (type 1, mask 3) — connection only
+            val chargeCaseCallback = AccessoryEventBinder(
+                onAccessoryEvent = { from, to ->
+                    isInChargeCase = (to == STATE_CONNECTED)
+                    Log.d(TAG, "Charge case: ${if (isInChargeCase) "connected" else "disconnected"}")
+                    notifyCallbacks()
+                },
+                onBatteryLevelChangeEvent = { _, _ -> }
+            )
+            val caseResult = subscribeRaw(1, CASE_PAD_STATE_MASK, chargeCaseCallback)
+            Log.i(TAG, "Subscribed to charge case (type 1), result=$caseResult")
+
+            subscribed = true
+            Log.i(TAG, "Subscribed to all accessory state events")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to subscribe to accessory events", e)
+        }
+    }
+
+    /**
+     * Fetch current booster battery level and charging status via reflection.
+     * Stock: PowerLevelManager calls getBatteryState(0, state) after connect.
+     */
+    private fun refreshBoosterBattery() {
+        try {
+            val batteryStateObject = batteryStateClass.getConstructor().newInstance()
+            val result =
+                getBatteryStateMethod.invoke(deviceManagerService, 0, batteryStateObject) as Int
+            if (result == 0) {
+                val levelPercentField = batteryStateClass.getField("levelPercent")
+                boosterLevel = levelPercentField.getInt(batteryStateObject)
+
+                val isChargingField = batteryStateClass.getField("isCharging")
+                boosterCharging = isChargingField.getBoolean(batteryStateObject)
+
+                Log.d(TAG, "Booster battery: ${boosterLevel}%, charging=$boosterCharging")
+            } else {
+                Log.w(TAG, "getBatteryState failed, result=$result")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error refreshing booster battery", e)
+        }
+    }
+
+    // ─── Callback notification ───
+
+    private fun buildBatteryInfo(): AccessoryBatteryInfo {
+        val isConnected = boosterConnectionState == STATE_CONNECTED
+        return AccessoryBatteryInfo().apply {
+            boosterBatteryLevel = if (isConnected) boosterLevel else -1
+            boosterBatteryCharging = isConnected && boosterCharging
+            boosterBatteryConnected = isConnected
+            boosterConnectionState = this@AccessoryProvider.boosterConnectionState
+            this.isOnChargePad = this@AccessoryProvider.isOnChargePad
+            this.isInChargeCase = this@AccessoryProvider.isInChargeCase
+        }
+    }
+
+    private fun notifyCallbacks() {
+        val info = buildBatteryInfo()
+        val dead = mutableListOf<IAccessoryCallback>()
+
+        sdkCallbacks.forEach { cb ->
+            safeCallback(TAG, {
+                cb.onBatteryInfoChanged(info)
+            }, onDeadObject = {
+                dead.add(cb)
+            })
+        }
+
+        dead.forEach { deregisterCallback(it) }
+    }
+
+    // ─── Connection ───
 
     private fun connectToDeviceManager() {
         try {

--- a/bridge-shell/src/main/java/com/penumbraos/bridge_shell/provider/AccessoryProvider.kt
+++ b/bridge-shell/src/main/java/com/penumbraos/bridge_shell/provider/AccessoryProvider.kt
@@ -13,21 +13,11 @@ import java.lang.reflect.Method
 
 private const val TAG = "AccessoryProvider"
 
-/**
- * Provides battery and accessory state from humane.devicemanager.
- *
- * Uses reflection to call IDeviceManager methods (isConnected, getBatteryState).
- *
- * SELinux on the AI Pin blocks binder `transfer` from shell context to
- * device_manager, so we cannot use push-based subscriptions
- * (subscribeToAccessoryState). Instead, we poll the device manager at a
- * regular interval and notify SDK callbacks when state changes.
- *
- * Stock subscription pattern (from decompiled PowerLevelManager.java):
- *   - Booster (type 0): connection state + battery level
- *   - Charge pad (type 2): connection state only
- *   - Charge case (type 1): connection state only
- */
+private const val STATE_DISCONNECTED = 1
+private const val STATE_CONNECTED = 2
+private const val STATE_MAYBE_CONNECTED = 128
+private const val POLL_INTERVAL_MS = 5000L
+
 class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
 
     private var deviceManagerService: Any? = null
@@ -39,46 +29,16 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
     private var isConnectedMethod: Method
     private var batteryStateClass: Class<*>
 
-    // ─── Cached live state (updated by polling) ───
+    private var boosterLevel: Int = -1
+    private var boosterCharging: Boolean = false
+    private var boosterConnectionState: Int = STATE_DISCONNECTED
+    private var isOnChargePad: Boolean = false
+    private var isInChargeCase: Boolean = false
 
-    /** Booster battery level percent (0-100, or -1 if disconnected) */
-    @Volatile private var boosterLevel: Int = -1
-
-    /** Whether booster is currently charging */
-    @Volatile private var boosterCharging: Boolean = false
-
-    /**
-     * Booster connection state (stock DMAccessoryState values):
-     *   1 = DISCONNECTED
-     *   2 = CONNECTED
-     *   128 = MAYBE_CONNECTED
-     */
-    @Volatile private var boosterConnectionState: Int = STATE_DISCONNECTED
-
-    /** Whether the pin is sitting on the charge pad */
-    @Volatile private var isOnChargePad: Boolean = false
-
-    /** Whether the pin is in the charge case */
-    @Volatile private var isInChargeCase: Boolean = false
-
-    // ─── SDK callbacks ───
-
-    private val sdkCallbacks = mutableListOf<IAccessoryCallback>()
-
-    // ─── Polling ───
+    private val callbacks = mutableListOf<IAccessoryCallback>()
 
     private var pollingThread: Thread? = null
     @Volatile private var pollingActive = false
-
-    companion object {
-        // Stock DMAccessoryState constants
-        const val STATE_DISCONNECTED = 1
-        const val STATE_CONNECTED = 2
-        const val STATE_MAYBE_CONNECTED = 128
-
-        /** Polling interval in milliseconds */
-        const val POLL_INTERVAL_MS = 5_000L
-    }
 
     init {
         val classLoader = getApkClassLoader(context, "humane.experience.settings")
@@ -97,10 +57,10 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
         isConnectedMethod = iDeviceManagerClass.getMethod("isConnected", Int::class.java)
     }
 
-    // ─── IAccessoryProvider implementation ───
-
     override fun getBatteryInfo(): AccessoryBatteryInfo? {
-        ensureConnected()
+        if (deviceManagerService == null || deviceManagerBinder?.isBinderAlive != true) {
+            connectToDeviceManager()
+        }
         if (deviceManagerService == null) return null
 
         return try {
@@ -108,7 +68,8 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
             buildBatteryInfo()
         } catch (e: Exception) {
             Log.e(TAG, "Error getting battery info", e)
-            handleConnectionError()
+            deviceManagerService = null
+            deviceManagerBinder = null
             null
         }
     }
@@ -120,49 +81,38 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
             }
         }, 0)
 
-        sdkCallbacks.add(callback)
-        Log.i(TAG, "Registered callback (total: ${sdkCallbacks.size})")
-
-        // Start polling on first callback registration
+        callbacks.add(callback)
         startPolling()
 
-        // Send initial state immediately
         try {
-            ensureConnected()
+            if (deviceManagerService == null || deviceManagerBinder?.isBinderAlive != true) {
+                connectToDeviceManager()
+            }
             if (deviceManagerService != null) {
                 pollAllAccessoryState()
             }
             callback.onBatteryInfoChanged(buildBatteryInfo())
         } catch (e: Exception) {
-            Log.w(TAG, "Failed to send initial battery info", e)
-            handleConnectionError()
-            // Still send what we have (defaults)
-            try { callback.onBatteryInfoChanged(buildBatteryInfo()) } catch (_: Exception) {}
+            Log.e(TAG, "Failed to send initial battery info", e)
+            deviceManagerService = null
+            deviceManagerBinder = null
         }
     }
 
     override fun deregisterCallback(callback: IAccessoryCallback) {
-        sdkCallbacks.remove(callback)
-        Log.i(TAG, "Deregistered callback (remaining: ${sdkCallbacks.size})")
+        callbacks.remove(callback)
 
-        // Stop polling when no callbacks remain
-        if (sdkCallbacks.isEmpty()) {
+        if (callbacks.count() < 1) {
+            Log.w(TAG, "Deregistering accessory listener")
             stopPolling()
         }
     }
 
-    // ─── Polling loop ───
-
-    /**
-     * Start a background polling thread that queries the device manager
-     * every [POLL_INTERVAL_MS] and notifies callbacks on state changes.
-     */
     private fun startPolling() {
         if (pollingActive) return
         pollingActive = true
 
         pollingThread = Thread({
-            Log.i(TAG, "Polling thread started (interval=${POLL_INTERVAL_MS}ms)")
             while (pollingActive) {
                 try {
                     Thread.sleep(POLL_INTERVAL_MS)
@@ -172,19 +122,23 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
                 if (!pollingActive) break
 
                 try {
-                    ensureConnected()
+                    if (deviceManagerService == null || deviceManagerBinder?.isBinderAlive != true) {
+                        connectToDeviceManager()
+                    }
                     if (deviceManagerService != null) {
                         val changed = pollAllAccessoryState()
                         if (changed) {
-                            notifyCallbacks()
+                            callCallback { callback ->
+                                callback.onBatteryInfoChanged(buildBatteryInfo())
+                            }
                         }
                     }
                 } catch (e: Exception) {
-                    Log.w(TAG, "Poll cycle failed: ${e.message}")
-                    handleConnectionError()
+                    Log.e(TAG, "Poll cycle failed", e)
+                    deviceManagerService = null
+                    deviceManagerBinder = null
                 }
             }
-            Log.i(TAG, "Polling thread stopped")
         }, "AccessoryProvider-poll").also {
             it.isDaemon = true
             it.start()
@@ -195,66 +149,66 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
         pollingActive = false
         pollingThread?.interrupt()
         pollingThread = null
-        Log.i(TAG, "Polling stopped")
     }
 
-    /**
-     * Poll all accessory types and update cached state.
-     * Returns true if any state changed since last poll.
-     */
     private fun pollAllAccessoryState(): Boolean {
         val svc = deviceManagerService ?: return false
         var changed = false
 
-        try {
-            // Poll booster (type 0)
-            val oldBoosterConn = boosterConnectionState
-            val oldBoosterLevel = boosterLevel
-            val oldBoosterCharging = boosterCharging
+        // Booster (type 0)
+        val oldBoosterConn = boosterConnectionState
+        val oldBoosterLevel = boosterLevel
+        val oldBoosterCharging = boosterCharging
 
-            val boosterConnStatus = isConnectedMethod.invoke(svc, 0) as Int
-            boosterConnectionState = boosterConnStatus
+        val boosterConnStatus = isConnectedMethod.invoke(svc, 0) as Int
+        boosterConnectionState = boosterConnStatus
 
-            if (boosterConnStatus == STATE_CONNECTED) {
-                val batteryStateObject = batteryStateClass.getConstructor().newInstance()
-                val result = getBatteryStateMethod.invoke(svc, 0, batteryStateObject) as Int
-                if (result == 0) {
-                    boosterLevel = batteryStateClass.getField("levelPercent").getInt(batteryStateObject)
-                    boosterCharging = batteryStateClass.getField("isCharging").getBoolean(batteryStateObject)
-                }
-            } else {
-                boosterLevel = 0
-                boosterCharging = false
+        if (boosterConnStatus == STATE_CONNECTED) {
+            val batteryStateObject = batteryStateClass.getConstructor().newInstance()
+            val result = getBatteryStateMethod.invoke(svc, 0, batteryStateObject) as Int
+            if (result == 0) {
+                boosterLevel = batteryStateClass.getField("levelPercent").getInt(batteryStateObject)
+                boosterCharging = batteryStateClass.getField("isCharging").getBoolean(batteryStateObject)
             }
-
-            if (oldBoosterConn != boosterConnectionState ||
-                oldBoosterLevel != boosterLevel ||
-                oldBoosterCharging != boosterCharging) {
-                changed = true
-            }
-
-            // Poll charge pad (type 2)
-            val oldPad = isOnChargePad
-            val padStatus = isConnectedMethod.invoke(svc, 2) as Int
-            isOnChargePad = (padStatus == STATE_CONNECTED)
-            if (oldPad != isOnChargePad) changed = true
-
-            // Poll charge case (type 1)
-            val oldCase = isInChargeCase
-            val caseStatus = isConnectedMethod.invoke(svc, 1) as Int
-            isInChargeCase = (caseStatus == STATE_CONNECTED)
-            if (oldCase != isInChargeCase) changed = true
-
-        } catch (e: Exception) {
-            Log.w(TAG, "pollAllAccessoryState failed: ${e.message}")
-            handleConnectionError()
-            throw e
+        } else {
+            boosterLevel = 0
+            boosterCharging = false
         }
+
+        if (oldBoosterConn != boosterConnectionState ||
+            oldBoosterLevel != boosterLevel ||
+            oldBoosterCharging != boosterCharging) {
+            changed = true
+        }
+
+        // Charge pad (type 2)
+        val oldPad = isOnChargePad
+        val padStatus = isConnectedMethod.invoke(svc, 2) as Int
+        isOnChargePad = (padStatus == STATE_CONNECTED)
+        if (oldPad != isOnChargePad) changed = true
+
+        // Charge case (type 1)
+        val oldCase = isInChargeCase
+        val caseStatus = isConnectedMethod.invoke(svc, 1) as Int
+        isInChargeCase = (caseStatus == STATE_CONNECTED)
+        if (oldCase != isInChargeCase) changed = true
 
         return changed
     }
 
-    // ─── Callback notification ───
+    private fun callCallback(withCallback: (IAccessoryCallback) -> Unit) {
+        val callbacksToRemove = mutableListOf<IAccessoryCallback>()
+
+        callbacks.forEach { callback ->
+            safeCallback(TAG, {
+                withCallback(callback)
+            }, onDeadObject = {
+                callbacksToRemove.add(callback)
+            })
+        }
+
+        callbacksToRemove.forEach { callback -> deregisterCallback(callback) }
+    }
 
     private fun buildBatteryInfo(): AccessoryBatteryInfo {
         val isConnected = boosterConnectionState == STATE_CONNECTED
@@ -266,39 +220,6 @@ class AccessoryProvider(context: Context) : IAccessoryProvider.Stub() {
             this.isOnChargePad = this@AccessoryProvider.isOnChargePad
             this.isInChargeCase = this@AccessoryProvider.isInChargeCase
         }
-    }
-
-    private fun notifyCallbacks() {
-        val info = buildBatteryInfo()
-        val dead = mutableListOf<IAccessoryCallback>()
-
-        sdkCallbacks.forEach { cb ->
-            safeCallback(TAG, {
-                cb.onBatteryInfoChanged(info)
-            }, onDeadObject = {
-                dead.add(cb)
-            })
-        }
-
-        dead.forEach { deregisterCallback(it) }
-
-        if (dead.isEmpty()) {
-            Log.d(TAG, "Notified ${sdkCallbacks.size} callbacks: " +
-                "booster=${boosterLevel}% conn=${boosterConnectionState} " +
-                "charging=$boosterCharging pad=$isOnChargePad case=$isInChargeCase")
-        }
-    }
-
-    // ─── Connection management ───
-
-    private fun ensureConnected() {
-        if (deviceManagerService != null && deviceManagerBinder?.isBinderAlive == true) return
-        connectToDeviceManager()
-    }
-
-    private fun handleConnectionError() {
-        deviceManagerService = null
-        deviceManagerBinder = null
     }
 
     private fun connectToDeviceManager() {

--- a/sdk/src/main/java/com/penumbraos/sdk/api/AccessoryClient.kt
+++ b/sdk/src/main/java/com/penumbraos/sdk/api/AccessoryClient.kt
@@ -3,6 +3,7 @@ package com.penumbraos.sdk.api
 import android.util.Log
 import com.penumbraos.bridge.IAccessoryProvider
 import com.penumbraos.bridge.callback.IAccessoryCallback
+import com.penumbraos.bridge.types.AccessoryBatteryInfo as AidlAccessoryBatteryInfo
 import com.penumbraos.sdk.api.types.AccessoryBatteryReceiver
 import com.penumbraos.sdk.api.types.BoosterBatteryInfo
 import java.util.concurrent.ConcurrentHashMap
@@ -25,7 +26,7 @@ class AccessoryClient(private val accessoryProvider: IAccessoryProvider) {
 
     fun register(receiver: AccessoryBatteryReceiver) {
         val callbackStub = object : IAccessoryCallback.Stub() {
-            override fun onBatteryInfoChanged(info: com.penumbraos.bridge.types.AccessoryBatteryInfo) {
+            override fun onBatteryInfoChanged(info: AidlAccessoryBatteryInfo) {
                 receiver.onBatteryInfoChanged(BoosterBatteryInfo.fromAidl(info))
             }
         }

--- a/sdk/src/main/java/com/penumbraos/sdk/api/AccessoryClient.kt
+++ b/sdk/src/main/java/com/penumbraos/sdk/api/AccessoryClient.kt
@@ -2,11 +2,16 @@ package com.penumbraos.sdk.api
 
 import android.util.Log
 import com.penumbraos.bridge.IAccessoryProvider
+import com.penumbraos.bridge.callback.IAccessoryCallback
+import com.penumbraos.sdk.api.types.AccessoryBatteryReceiver
 import com.penumbraos.sdk.api.types.BoosterBatteryInfo
+import java.util.concurrent.ConcurrentHashMap
 
 private const val TAG = "AccessoryClient"
 
 class AccessoryClient(private val accessoryProvider: IAccessoryProvider) {
+    private val registeredCallbacks =
+        ConcurrentHashMap<AccessoryBatteryReceiver, IAccessoryCallback.Stub>()
 
     fun getBatteryInfo(): BoosterBatteryInfo? {
         return try {
@@ -15,6 +20,23 @@ class AccessoryClient(private val accessoryProvider: IAccessoryProvider) {
         } catch (e: Exception) {
             Log.e(TAG, "Failed to get battery info", e)
             null
+        }
+    }
+
+    fun register(receiver: AccessoryBatteryReceiver) {
+        val callbackStub = object : IAccessoryCallback.Stub() {
+            override fun onBatteryInfoChanged(info: com.penumbraos.bridge.types.AccessoryBatteryInfo) {
+                receiver.onBatteryInfoChanged(BoosterBatteryInfo.fromAidl(info))
+            }
+        }
+        registeredCallbacks[receiver] = callbackStub
+        accessoryProvider.registerCallback(callbackStub)
+    }
+
+    fun remove(receiver: AccessoryBatteryReceiver) {
+        val callbackStub = registeredCallbacks.remove(receiver)
+        if (callbackStub != null) {
+            accessoryProvider.deregisterCallback(callbackStub)
         }
     }
 }

--- a/sdk/src/main/java/com/penumbraos/sdk/api/types/AccessoryBatteryReceiver.kt
+++ b/sdk/src/main/java/com/penumbraos/sdk/api/types/AccessoryBatteryReceiver.kt
@@ -1,0 +1,5 @@
+package com.penumbraos.sdk.api.types
+
+interface AccessoryBatteryReceiver {
+    fun onBatteryInfoChanged(info: BoosterBatteryInfo)
+}

--- a/sdk/src/main/java/com/penumbraos/sdk/api/types/BoosterBatteryInfo.kt
+++ b/sdk/src/main/java/com/penumbraos/sdk/api/types/BoosterBatteryInfo.kt
@@ -5,7 +5,13 @@ import com.penumbraos.bridge.types.AccessoryBatteryInfo
 data class BoosterBatteryInfo(
     val batteryLevel: Int,
     val isCharging: Boolean,
-    val isConnected: Boolean
+    val isConnected: Boolean,
+    /** Stock DMAccessoryState: 1=disconnected, 2=connected, 128=maybe_connected */
+    val connectionState: Int = 1,
+    /** Whether the pin is sitting on the charge pad */
+    val isOnChargePad: Boolean = false,
+    /** Whether the pin is in the charge case */
+    val isInChargeCase: Boolean = false
 ) {
     companion object {
         fun fromAidl(
@@ -14,7 +20,10 @@ data class BoosterBatteryInfo(
             return BoosterBatteryInfo(
                 batteryLevel = aidlInfo.boosterBatteryLevel,
                 isCharging = aidlInfo.boosterBatteryCharging,
-                isConnected = aidlInfo.boosterBatteryConnected
+                isConnected = aidlInfo.boosterBatteryConnected,
+                connectionState = aidlInfo.boosterConnectionState,
+                isOnChargePad = aidlInfo.isOnChargePad,
+                isInChargeCase = aidlInfo.isInChargeCase
             )
         }
     }

--- a/sdk/src/main/java/com/penumbraos/sdk/api/types/BoosterBatteryInfo.kt
+++ b/sdk/src/main/java/com/penumbraos/sdk/api/types/BoosterBatteryInfo.kt
@@ -6,11 +6,8 @@ data class BoosterBatteryInfo(
     val batteryLevel: Int,
     val isCharging: Boolean,
     val isConnected: Boolean,
-    /** Stock DMAccessoryState: 1=disconnected, 2=connected, 128=maybe_connected */
     val connectionState: Int = 1,
-    /** Whether the pin is sitting on the charge pad */
     val isOnChargePad: Boolean = false,
-    /** Whether the pin is in the charge case */
     val isInChargeCase: Boolean = false
 ) {
     companion object {


### PR DESCRIPTION
Introduce AIDL callback support and push-based accessory state updates. Adds IAccessoryCallback AIDL and extends IAccessoryProvider with register/deregister methods; expands AccessoryBatteryInfo AIDL with connectionState, isOnChargePad, and isInChargeCase. Implement AccessoryEventBinder to speak the humane.devicemanager binder protocol and update AccessoryProvider to subscribe via raw binder transactions, cache live state, notify SDK callbacks, and refresh booster battery state. SDK changes include AccessoryBatteryReceiver interface, register/remove integration in AccessoryClient, and extended BoosterBatteryInfo mapping to include connection state, pad/case flags. These changes enable reliable subscription-based updates (charge pad/case and booster events) despite classloader/proxy constraints.